### PR TITLE
Fix for: Horizontal Scrolling In Tabular View 

### DIFF
--- a/app/assets/javascripts/results_table.jsx
+++ b/app/assets/javascripts/results_table.jsx
@@ -124,7 +124,7 @@ var ResultsTable = React.createClass({
         },this);
 
         return (
-            <div className="table-responsive">
+            <div className="table-responsive results-table">
                 <table className="table table-bordered table-hover">
                     <thead>
                     <TableHeader type={this.props.type}/>

--- a/public/stylesheets/results.css
+++ b/public/stylesheets/results.css
@@ -1563,3 +1563,9 @@ color: #44639A;
   display:none;
   /*background: lightgrey;*/
 }
+
+.results-table{
+  max-height: 75vh;
+  max-width:  75vw;
+  overflow: auto;
+}


### PR DESCRIPTION
In Tablular View of Search Results, horizontal scroll disappears (to the bottom of the table) when there are a lot of results.

In this commit, search result table is bound to browser view port so user can access horizontal scroll at any time.